### PR TITLE
add route for recalculating achievements

### DIFF
--- a/src/router/athletes.js
+++ b/src/router/athletes.js
@@ -126,6 +126,13 @@ const addMatchForSingleAthlete = utils.dreamCatcher(async (req, res) => {
   return res.status(201).json(utils.mapDbObjectToResponse(newBout));
 });
 
+const recalculateAthleteAchievement = utils.dreamCatcher(async (req, res) => {
+  const { athleteId } = req.params;
+
+  await utils.recalculateAndUpdateAchievements(req.db, athleteId);
+  return res.status(200).json({ message: `Successfully triggered recalculation for id: ${athleteId}` });
+});
+
 export default {
   getSingleOrAllAthletes,
   getAllAthletesDetailed,
@@ -133,4 +140,5 @@ export default {
   updateAthlete,
   getMatchesForAthlete,
   addMatchForSingleAthlete,
+  recalculateAthleteAchievement,
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -56,6 +56,7 @@ export default function (app) {
   apiRoutes.post('/athletes', requireAuth, restrictAccessTo([ADMIN, COACH]), athletes.createAthlete);
   apiRoutes.put('/athletes/:id', requireAuth, restrictAccessTo([ADMIN, COACH]), athletes.updateAthlete);
   apiRoutes.post('/athletes/:athleteId/bouts', requireAuth, athletes.addMatchForSingleAthlete);
+  apiRoutes.post('/athletes/:athleteId/recalculate', requireAuth, restrictAccessTo([ADMIN]), athletes.recalculateAthleteAchievement);
 
   /**
    * Clubs


### PR DESCRIPTION
POST athletes/:athleteId/recalculate can now be called to manually
trigger a new achievement calculation.